### PR TITLE
Create new projects with gauge-java 0.7.9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "java_maven_selenium",
   "description": "Gauge template for Java plugin with Maven as Build tool and Selenium as driver to interact with a web browser",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "postInstallCmd": "",
   "postInstallMsg": "Run specifications with \"mvn clean test\" in project root."
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
-            <version>0.7.4</version>
+            <version>0.7.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This updates default version of gauge-java for new Maven projects to 0.7.9