### PR TITLE
Downgrading the reflections version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
+            <version>0.9.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
When Project created with this template Gauge tests are not running. However, it works when ```reflections``` version is downgraded. 